### PR TITLE
ci(pre-commit): update pre-commit-hooks-ros

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,7 +59,7 @@ repos:
       - id: isort
 
   - repo: https://github.com/psf/black
-    rev: 22.1.0
+    rev: 22.3.0
     hooks:
       - id: black
         args: [--line-length=100]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,12 +34,13 @@ repos:
       - id: yamllint
 
   - repo: https://github.com/tier4/pre-commit-hooks-ros
-    rev: v0.4.0
+    rev: v0.6.0
     hooks:
       - id: prettier-xacro
       - id: prettier-launch-xml
       - id: prettier-package-xml
       - id: sort-package-xml
+      - id: ros-include-guard
 
   - repo: https://github.com/shellcheck-py/shellcheck-py
     rev: v0.8.0.3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -80,16 +80,4 @@ repos:
             flake8-quotes,
           ]
 
-  - repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: v13.0.0
-    hooks:
-      - id: clang-format
-
-  - repo: https://github.com/cpplint/cpplint
-    rev: 1.5.5
-    hooks:
-      - id: cpplint
-        args: [--quiet]
-        exclude: .cu
-
 exclude: .svg

--- a/sample_vehicle_description/urdf/vehicle.xacro
+++ b/sample_vehicle_description/urdf/vehicle.xacro
@@ -1,11 +1,7 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
-
   <!-- load parameter -->
-  <xacro:property
-    name="vehicle_info"
-    value="${load_yaml('$(find sample_vehicle_description)/config/vehicle_info.param.yaml')}"
-  />
+  <xacro:property name="vehicle_info" value="${load_yaml('$(find sample_vehicle_description)/config/vehicle_info.param.yaml')}"/>
 
   <!-- vehicle body -->
   <link name="base_link">
@@ -16,5 +12,4 @@
       </geometry>
     </visual>
   </link>
-
 </robot>


### PR DESCRIPTION
See https://github.com/tier4/pre-commit-hooks-ros/pull/50 and https://github.com/tier4/pre-commit-hooks-ros/releases/tag/v0.6.0.

Related: https://github.com/autowarefoundation/autoware/pull/143