### PR TITLE
fix: suppress xacro warning

### DIFF
--- a/sample_vehicle_description/urdf/vehicle.xacro
+++ b/sample_vehicle_description/urdf/vehicle.xacro
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
   <!-- load parameter -->
-  <xacro:property name="vehicle_info" value="${load_yaml('$(find sample_vehicle_description)/config/vehicle_info.param.yaml')}"/>
+  <xacro:property name="vehicle_info" value="${xacro.load_yaml('$(find sample_vehicle_description)/config/vehicle_info.param.yaml')}"/>
 
   <!-- vehicle body -->
   <link name="base_link">


### PR DESCRIPTION
Signed-off-by: Daisuke Nishimatsu <border_goldenmarket@yahoo.co.jp>

## Description

suppress xacro warning below.
```
warning: Using load_yaml() directly is deprecated. Use xacro.load_yaml() instead.
warning: Using load_yaml() directly is deprecated. Use xacro.load_yaml() instead.
warning: Using load_yaml() directly is deprecated. Use xacro.load_yaml() instead.
```

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
