### PR TITLE
feat(simple_planning_simulator): add enable_road_slope_simulation param

### DIFF
--- a/sample_vehicle_description/config/simulator_model.param.yaml
+++ b/sample_vehicle_description/config/simulator_model.param.yaml
@@ -16,4 +16,4 @@
     steer_time_constant: 0.27 # time constant of the 1st-order steering dynamics
     x_stddev: 0.0001 # x standard deviation for dummy covariance in map coordinate
     y_stddev: 0.0001 # y standard deviation for dummy covariance in map coordinate
-    enable_road_slope_simulation: true # if true, slopes in the lanelet map are used to apply an extra acceleration to the ego vehicle
+    enable_road_slope_simulation: false # if true, slopes in the lanelet map are used to apply an extra acceleration to the ego vehicle

--- a/sample_vehicle_description/config/simulator_model.param.yaml
+++ b/sample_vehicle_description/config/simulator_model.param.yaml
@@ -16,3 +16,4 @@
     steer_time_constant: 0.27 # time constant of the 1st-order steering dynamics
     x_stddev: 0.0001 # x standard deviation for dummy covariance in map coordinate
     y_stddev: 0.0001 # y standard deviation for dummy covariance in map coordinate
+    enable_road_slope_simulation: true # if true, slopes in the lanelet map are used to apply an extra acceleration to the ego vehicle


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
Add the parameter used to simulate slopes with the simple_planning_simulator. 

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Psim

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Slopes in the map correctly increase or decrease the ego acceleration and setting `enable_slope_compensation: true` in the longitudinal controller becomes necessary.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
