### PR TITLE
feat: set enable_road_slope_simulation to true

### DIFF
--- a/sample_vehicle_description/config/simulator_model.param.yaml
+++ b/sample_vehicle_description/config/simulator_model.param.yaml
@@ -6,6 +6,7 @@
     initialize_source: "INITIAL_POSE_TOPIC" #  options: ORIGIN / INITIAL_POSE_TOPIC
     timer_sampling_time_ms: 25
     add_measurement_noise: False # the Gaussian noise is added to the simulated results
+    enable_road_slope_simulation: True
     vel_lim: 50.0 # limit of velocity
     vel_rate_lim: 7.0 # limit of acceleration
     steer_lim: 1.0 # limit of steering angle

--- a/sample_vehicle_description/config/simulator_model.param.yaml
+++ b/sample_vehicle_description/config/simulator_model.param.yaml
@@ -6,7 +6,6 @@
     initialize_source: "INITIAL_POSE_TOPIC" #  options: ORIGIN / INITIAL_POSE_TOPIC
     timer_sampling_time_ms: 25
     add_measurement_noise: False # the Gaussian noise is added to the simulated results
-    enable_road_slope_simulation: True
     vel_lim: 50.0 # limit of velocity
     vel_rate_lim: 7.0 # limit of acceleration
     steer_lim: 1.0 # limit of steering angle
@@ -17,4 +16,4 @@
     steer_time_constant: 0.27 # time constant of the 1st-order steering dynamics
     x_stddev: 0.0001 # x standard deviation for dummy covariance in map coordinate
     y_stddev: 0.0001 # y standard deviation for dummy covariance in map coordinate
-    enable_road_slope_simulation: false # if true, slopes in the lanelet map are used to apply an extra acceleration to the ego vehicle
+    enable_road_slope_simulation: true # if true, slopes in the lanelet map are used to apply an extra acceleration to the ego vehicle


### PR DESCRIPTION
## Description

Since `enable_slope_compensation` in the Autoware's controller is true by default, the simulator's enable_road_slope_simulation should be true by defaul.t
https://github.com/autowarefoundation/autoware_launch/blob/7df85a85c7eba27cc1b96ceb58304d8515c7b9ee/autoware_launch/config/control/trajectory_follower/longitudinal/pid.param.yaml#L8
<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

psim

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->
The simple planning simulator will simulate a force by a road slope.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
